### PR TITLE
Fix code scanning alert no. 96: Potential use after free

### DIFF
--- a/redalert/unit.cpp
+++ b/redalert/unit.cpp
@@ -4400,8 +4400,10 @@ BulletClass* UnitClass::Fire_At(TARGET target, int which)
 
         if (bullet != NULL) {
 #ifdef FIXIT_CSII //	checked - ajw 9/28/98
-            if (Class->Type == UNIT_DEMOTRUCK && IsActive)
+            if (Class->Type == UNIT_DEMOTRUCK && IsActive) {
                 delete this;
+                return NULL;
+            }
 #endif
             /*
             **	Possible reload timer set.


### PR DESCRIPTION
Fixes [https://github.com/SashaXser/Vanilla-Conquer/security/code-scanning/96](https://github.com/SashaXser/Vanilla-Conquer/security/code-scanning/96)

To fix the problem, we need to ensure that no access to the object occurs after it has been deleted. One way to achieve this is to return immediately after the `delete this` statement to prevent any further execution of code that might access the deleted object. This approach maintains the existing functionality while ensuring that the object is not accessed after it has been freed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
